### PR TITLE
[OFFAPPS-386][ZD909384] Organisation shown should be derived from the ticket not the user

### DIFF
--- a/app.js
+++ b/app.js
@@ -268,7 +268,6 @@
         if (this.ticket().requester()) {
           this.countedAjax('getUser', this.ticket().requester().id());
           this.countedAjax('getUserFields');
-          this.countedAjax('getOrganizationFields');
           if (!this.storage.locales) {
             this.countedAjax('getLocales');
           }
@@ -396,11 +395,11 @@
       this.storage.user.organization = data.organizations[0];
       var ticketOrg = this.ticket().organization();
       if (ticketOrg) {
-        this.storage.user.organization = _.reduce(['id', 'name', 'tags'], function(memo, name) {
-          memo[name] = ticketOrg[name]();
-          return memo;
-        }, {});
+        this.storage.user.organization = _.find(data.organizations, function(org) {
+          return org.id === ticketOrg.id();
+        });
       }
+      this.countedAjax('getOrganizationFields');
       if (data.user && data.user.id) {
         this.countedAjax('getTickets', this.storage.user.id);
       }

--- a/app.js
+++ b/app.js
@@ -394,6 +394,13 @@
         return ident;
       });
       this.storage.user.organization = data.organizations[0];
+      var ticketOrg = this.ticket().organization();
+      if (ticketOrg) {
+        this.storage.user.organization = _.reduce(['id', 'name', 'tags'], function(memo, name) {
+          memo[name] = ticketOrg[name]();
+          return memo;
+        }, {});
+      }
       if (data.user && data.user.id) {
         this.countedAjax('getTickets', this.storage.user.id);
       }


### PR DESCRIPTION
:koala: :bug: 

When an organization is set on a Ticket, we should use that organization for display in the app, rather than the user's default organization.  If there is no organization set on the Ticket, the app will fall back to the user's default organization.

/cc @zendesk/quokka

### Tasks
- [x] Deploy zendesk/zendesk_app_framework#336

### References
- ZAF PR: zendesk/zendesk_app_framework#336
- Jira link: https://zendesk.atlassian.net/browse/OFFAPPS-386

### Risks
 - [MEDIUM] The incorrect organization could be shown in the User Data App, or no organization at all. 