### PR TITLE
AF-127 use search if there are many tickets

### DIFF
--- a/app.js
+++ b/app.js
@@ -60,8 +60,7 @@
         };
       },
 
-      searchTickets: function(userId, statusIndex) {
-        var status = this.TICKET_STATUSES[statusIndex];
+      searchTickets: function(userId, status) {
         return {
           url: helpers.fmt('/api/v2/search.json?query=type:ticket requester:%@ status:%@', userId, status),
           dataType: 'json'
@@ -508,7 +507,7 @@
       if (this.ticketSearchStatus === this.TICKET_STATUSES.length - 1) {
         return;
       }
-      this.countedAjax('searchTickets', this.storage.user.id, ++this.ticketSearchStatus);
+      this.countedAjax('searchTickets', this.storage.user.id, this.TICKET_STATUSES[++this.ticketSearchStatus]);
     },
 
     onGetTicketsDone: function(data) {
@@ -516,7 +515,7 @@
       if (data.next_page) {
         if (data.count / data.tickets.length - 1 > this.TICKET_STATUSES.length) {
           this.ticketSearchStatus = 0;
-          this.countedAjax('searchTickets', this.storage.user.id, this.ticketSearchStatus);
+          this.countedAjax('searchTickets', this.storage.user.id, this.TICKET_STATUSES[this.ticketSearchStatus]);
           return;
         }
         var pageNumber = data.next_page.match(/page=(\d+)/)[1];

--- a/app.js
+++ b/app.js
@@ -513,6 +513,7 @@
     onGetTicketsDone: function(data) {
       this.storage.tickets.push.apply(this.storage.tickets, data.tickets);
       if (data.next_page) {
+        // determine if it is fewer API hits to search or to continue loading all the tickets
         if (data.count / data.tickets.length - 1 > this.TICKET_STATUSES.length) {
           this.ticketSearchStatus = 0;
           this.countedAjax('searchTickets', this.storage.user.id, this.TICKET_STATUSES[this.ticketSearchStatus]);


### PR DESCRIPTION
:koala:

This optimises for making the least number of requests. Each hit returns 100 tickets and there are 6 possible statuses. We can fetch the count for each status in one hit (makes 6 API calls) or we can fetch the tickets 100 at a time and group them to count. So if there are 701 or more tickets (8 API calls) this PR prefers to search.

We never paginated organisations so org tickets have been left as they were.

/cc @zendesk/quokka

### References
 - Jira link: https://zendesk.atlassian.net/browse/AF-127

### Risks
 - Slow