### PR TITLE
reordering statuses to match the ones visible when submiting tickets

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -29,5 +29,5 @@
     "new_ticket_sidebar"
   ],
   "frameworkVersion": "1.0",
-  "version": "1.0.10"
+  "version": "1.0.11"
 }

--- a/templates/display.hdbs
+++ b/templates/display.hdbs
@@ -46,16 +46,16 @@
           <span class="count open">{{{tickets.open}}}</span>
         </li>
         <li>
-          <span class="ticket_status_label solved">{{t "ticket_status.solved"}}</span>
-          <span class="count solved">{{{tickets.solved}}}</span>
-        </li>
-        <li>
           <span class="ticket_status_label pending">{{t "ticket_status.pending"}}</span>
           <span class="count pending">{{{tickets.pending}}}</span>
         </li>
         <li>
           <span class="ticket_status_label hold">{{t "ticket_status.hold"}}</span>
           <span class="count hold">{{{tickets.hold}}}</span>
+        </li>
+        <li>
+          <span class="ticket_status_label solved">{{t "ticket_status.solved"}}</span>
+          <span class="count solved">{{{tickets.solved}}}</span>
         </li>
         <li>
           <span class="ticket_status_label closed">{{t "ticket_status.closed"}}</span>


### PR DESCRIPTION
minor change: displaying **solved** between **on-hold** and **closed**
