### PR TITLE
Remove biased language from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 Zendesk User Data App
 ===============
 
-This is the [User Data App](https://www.zendesk.com/apps/user-data) for New Zendesk. The App displays relevant information about the user and his ticket, fields and organizations
+This is the [User Data App](https://www.zendesk.com/apps/user-data) for New Zendesk. The App displays relevant information about the user and their ticket, fields and organizations
 
 ## Deployment
 This app is deployed using [ZAT](https://github.com/zendesk/zendesk_apps_tools) via [Samson](https://github.com/zendesk/samson) on staging ([link for Zendesk deployers](https://samson.zende.sk/projects/user_data_app/stages/staging)).


### PR DESCRIPTION
Removes unnecessarily gendered pronoun to refer to users. Per [alex](http://alexjs.com/#demo),

`his may be insensitive, use their, theirs, them instead`