### PR TITLE
[OFFAPPS-775] Style updates for new proxima-nova font changes in lotus

### DIFF
--- a/app.css
+++ b/app.css
@@ -64,6 +64,7 @@
         height: 72px;
         box-sizing: border-box;
         border: 0px;
+        font-size: 14px;
       }
 
       &.builtin.tags {
@@ -103,15 +104,16 @@
       }
 
       h4 {
-        font-size: 11px;
+        font-size: 14px;
         color:  #999;
         font-weight: normal;
+        margin-bottom: 10px;
       }
 
       p {
-        font-size: 12px;
-        color:  #333;
-        line-height: 1.5;
+        font-size: 14px;
+        color:  #555;
+        line-height: 1.4;
       }
     }
   }
@@ -170,14 +172,14 @@
     }
 
     .avatar {
-      width: 40px;
-      height: 40px;
+      width: 50px;
+      height: 50px;
       float: left;
 
       &.default {
         background-image: app-asset-url("avatar.png");
         background-size: cover;
-        border-radius: 4px;
+        border-radius: 50px;
 
         &.org {
           background-image: app-asset-url("org.png");
@@ -185,27 +187,27 @@
       }
 
       img {
-        border-radius: 4px;
+        border-radius: 50px;
       }
     }
 
     .contacts {
-      margin-left: 55px;
+      margin-left: 65px;
 
       div {
         color: #999;
-        font-size: 11px;
-        margin-bottom: 3px;
+        font-size: 14px;
+        /*margin-bottom: 3px;*/
         word-wrap: break-word;
 
         &.name {
-          font-size: 14px;
-          line-height: 1.286;
-          font-weight: bold;
-          margin-bottom: 4px;
+          font-size: 16px;
+          /*line-height: 1.286;*/
+          font-weight: 600;
+          /*margin-bottom: 4px;*/
 
           a {
-            color: #444;
+            color: #555;
           }
         }
 
@@ -227,32 +229,35 @@
 
     .counts {
       margin: 0px;
-      margin-top: 9px;
+      margin-top: 30px;
 
       li {
         display: inline-block;
-        font-size: 11px;
+        font-size: 12px;
         color: #999;
         width: 50px;
-        line-height: 1.286;
+        line-height: 1.486;
 
         a {
           color: #999;
+          position: relative;
+          top: 2px;
         }
 
         .ticket_status_label {
-          font-size: 9px;
-          line-height: 13px;
+          font-size: 10px;
+          line-height: 14px;
           padding: 0;
           padding-left: 4px;
           padding-right: 4px;
-          height: 4px;
+          height: 15px;
           display: inline-block;
           vertical-align: middle;
           box-sizing: border-box;
           white-space: nowrap;
           text-align: center;
           opacity: 0.6;
+          width: 15px;
         }
       }
     }
@@ -264,7 +269,7 @@
     padding-top: 0px;
     padding-bottom: 15px;
     display: block;
-    margin-top: 20px;
+    margin-top: 30px;
 
     .arrow {
       margin-top: 12px;

--- a/app.css
+++ b/app.css
@@ -197,14 +197,11 @@
       div {
         color: #999;
         font-size: 14px;
-        /*margin-bottom: 3px;*/
         word-wrap: break-word;
 
         &.name {
           font-size: 16px;
-          /*line-height: 1.286;*/
           font-weight: 600;
-          /*margin-bottom: 4px;*/
 
           a {
             color: #555;


### PR DESCRIPTION
:v:

/cc @zendesk/vegemite

### Description

Since the font in Lotus changed to proxima-nova, the fonts in the User Data app became _really_ small. Updated styles to match the spec below:

![user_data_spec_07062016](https://cloud.githubusercontent.com/assets/4024784/16639740/b4d69f46-4435-11e6-9265-068289ff9657.png)

Before
![](https://cl.ly/1i2h0i3V3j1a/Image%202016-07-07%20at%2011.17.32%20AM.png)

After
![](https://cl.ly/3E3v0X0C1I2l/Image%202016-07-07%20at%2011.17.11%20AM.png)

### References
* JIRA: https://zendesk.atlassian.net/browse/OFFAPPS-775

### Risks
* Needs to be checked in other browsers.
