### PR TITLE
[OFFAPPS-1027] Fix Custom User Field to show Title instead of Tag

### DIFF
--- a/src/javascript/app.js
+++ b/src/javascript/app.js
@@ -573,7 +573,8 @@ const app = {
           ? JSON.parse(setting('selectedFields'))
           : ['##builtin_tags', '##builtin_details', '##builtin_notes'], field.key),
         editable: field.editable,
-        type: field.type
+        type: field.type,
+        custom_field_options: field.custom_field_options
       }
     })
 


### PR DESCRIPTION
[OFFAPPS-1027] Fix Custom User Field to show Title instead of Tag

## Description
When using this app, the custom dropdown field shows the tag, not the title. A fix has been implemented to show the title instead of tag.

## Tasks
- [x] Investigate and Replicate Issue on Local Machine based on ReadMe <- 👍  (`zat server -p dist/` & `npm run watch`)
- [x] Trace the source of the bug by understanding the process from HTML template through to Javascript Functions that renders this value.
- [x] Check that code change reflects in the browser.
- [x] Make sure that other tests don't break. 

## Implementation notes
trial and error then BOOM!

<details>
<summary>Undefined</summary>

<img width="500" alt="undefined_1" src="https://user-images.githubusercontent.com/17760485/44821817-f1d2ba00-ac3a-11e8-9e97-d9d94bd852d8.jpg">

<img width="1110" alt="undefined_1" src="https://user-images.githubusercontent.com/17760485/44821727-7d981680-ac3a-11e8-97b5-f8c0fca32c82.png">

<img width="207" alt="undefined_2" src="https://user-images.githubusercontent.com/17760485/44821732-7ffa7080-ac3a-11e8-9421-2defe430b27f.png">

<img width="576" alt="undefined_3" src="https://user-images.githubusercontent.com/17760485/44821734-81c43400-ac3a-11e8-81d5-a50d12ebd518.png">
</details>


<details>
<summary>Defined</summary>

<img width="571" alt="defined_1" src="https://user-images.githubusercontent.com/17760485/44821749-97d1f480-ac3a-11e8-98e6-d82996cbc609.png">

<img width="668" alt="defined_2" src="https://user-images.githubusercontent.com/17760485/44821752-9acce500-ac3a-11e8-812c-70e0b84aade9.png">

<img width="1075" alt="defined_3" src="https://user-images.githubusercontent.com/17760485/44821754-9dc7d580-ac3a-11e8-9e69-05c5212d6860.png">
</details>

## References
[JIRA ticket](https://zendesk.atlassian.net/browse/OFFAPPS-1027)
Chris Sos

## Screenshots
<details>
<summary>Admin Settings -> User Fields -> Custom User Field</summary>
<img width="778" alt="settings for custom user field" src="https://user-images.githubusercontent.com/17760485/44773253-6e21ba80-abb3-11e8-9e32-a5adb8da50e3.png">
</details>

<details>
<summary>App Before - field value showing tag</summary>
<img width="270" alt="before" src="https://user-images.githubusercontent.com/17760485/44773182-43376680-abb3-11e8-8b72-02a474a43234.png">
</details>

<details>
<summary>App After - field value showing title</summary>
<img width="271" alt="after" src="https://user-images.githubusercontent.com/17760485/44773312-a1fce000-abb3-11e8-89f4-3025b9269da4.png">
</details>

## CCs
@zendesk/apps-migration

## Risks
low
