### PR TITLE
[OFFAPPS-1034] Bugfixes for 'no requester'

### DIFF
--- a/spec/app_spec.js
+++ b/spec/app_spec.js
@@ -7,25 +7,26 @@ import sinon from 'sinon'
 
 describe('App', () => {
   describe('#toLocaleDate', () => {
-    let date;
+    let date
+
     before(() => {
       date = '2018-10-01T00:00:00+00:00' // October 1st, 2018
     })
 
     describe("dates are formatted for the user's locale", () => {
-      it ('formats date for en-US', () => {
+      it('formats date for en-US', () => {
         helpers.storage('currentUser', { locale: 'en-US', timeZone: { offset: 0 } })
         const result = app.toLocaleDate(date)
         assert.strictEqual(result, '10/1/2018')
       })
 
-      it ('formats date for en-GB', () => {
+      it('formats date for en-GB', () => {
         helpers.storage('currentUser', { locale: 'en-GB', timeZone: { offset: 0 } })
         const result = app.toLocaleDate(date)
         assert.strictEqual(result, '01/10/2018')
       })
 
-      it ('formats date for ko-KR', () => {
+      it('formats date for ko-KR', () => {
         helpers.storage('currentUser', { locale: 'ko-KR', timeZone: { offset: 0 } })
         const result = app.toLocaleDate(date)
         assert.strictEqual(result, '2018. 10. 1.')

--- a/src/javascript/app.js
+++ b/src/javascript/app.js
@@ -282,7 +282,7 @@ const app = {
             return option.value === result.value
           })
           result.value = (option) ? option.name : ''
-        } else if (!result.editable && result.value && typeof result.value === 'string') {
+        } else if (!result.editable && typeof result.value === 'string') {
           result.value = result.value.replace(/\n/g, '<br>')
           result.html = true
         }

--- a/src/javascript/app.js
+++ b/src/javascript/app.js
@@ -5,6 +5,7 @@ import client from './lib/client'
 import renderAdmin from '../templates/admin.hdbs'
 import renderDisplay from '../templates/display.hdbs'
 import renderNoRequester from '../templates/no_requester.hdbs'
+import errorMessage from '../templates/error.hdbs'
 import renderSpoke from '../templates/spoke.hdbs'
 import renderTags from '../templates/tags.hdbs'
 
@@ -37,8 +38,8 @@ const app = {
       app.fillEmptyStatuses(storage('ticketsCounters'))
       app.fillEmptyStatuses(storage('orgTicketsCounters'))
       app.showDisplay()
-    }).catch(() => {
-      const view = renderNoRequester()
+    }).catch((err) => {
+      const view = (err.message === 'no requester') ? renderNoRequester() : errorMessage({ msg: err.message })
       $('[data-main]').html(view)
       appResize()
     })

--- a/src/javascript/app.js
+++ b/src/javascript/app.js
@@ -259,7 +259,7 @@ const app = {
           result.html = true
         } else if (subkey === 'locale') {
           result.value = locales[result.value]
-        } else if (!result.editable) {
+        } else if (!result.editable && typeof result.value === 'string') {
           result.value = result.value.replace(/\n/g, '<br>')
           result.html = true
         }
@@ -281,10 +281,8 @@ const app = {
             return option.value === result.value
           })
           result.value = (option) ? option.name : ''
-        } else if (!result.editable && result.value) {
-          if (typeof result.value === 'string') {
-            result.value = result.value.replace(/\n/g, '<br>')
-          }
+        } else if (!result.editable && result.value && typeof result.value === 'string') {
+          result.value = result.value.replace(/\n/g, '<br>')
           result.html = true
         }
       }

--- a/src/main.scss
+++ b/src/main.scss
@@ -19,7 +19,7 @@ html, body {
   color: #333;
 }
 
-.no_requester {
+.no_requester, .error_message {
   text-align: center;
 }
 

--- a/src/templates/error.hdbs
+++ b/src/templates/error.hdbs
@@ -1,0 +1,5 @@
+<div class="admin" style="display: none"></div>
+
+<div class="error_message">
+  {{t "client.get.error" error=msg}}
+</div>


### PR DESCRIPTION
## Description
"No requester" was showing up on tickets that clearly had a requester.

Because the `.catch` function was simply showing the 'no requester' message, independent of the actual error, it caused confusion.

1) Fixed the actual error (cannot call replace on null).
2) Better error message

## References
[JIRA ticket](https://zendesk.atlassian.net/browse/OFFAPPS-1034)

## CCs
Anyone specific?
Unless there's a good reason not to:
@zendesk/apps-migration

## Risks
* [low] field isn't showing up correctly.