### PR TITLE
[OFFAPPS-1041] Display blocks of icon in-line

### DIFF
--- a/src/main.scss
+++ b/src/main.scss
@@ -189,7 +189,7 @@ i.icon_circle_arrow_left {
       left: 12px;
 
       a {
-        display: block;
+        display: inline-block;
         background-image: url("images/ico-social-sprite.png");
 
         &.facebook {


### PR DESCRIPTION
[OFFAPPS-1041] Display blocks of icon in-line

## Description
This implementation is to fix the display issues with social media icons.

## Tasks
- [x] Check with Chris if there is a protocol around UI changes (approvals etc)
- [x] Check with Chris if the icons sitting next to each other is alright?
- [x] Test in someone else's browser. 
    <details>
    <summary>Why? </summary>
    Because this other component looks very different ONLY on my local machine.
    <img width="261" alt="screen shot 2018-09-05 at 2 27 09 pm" src="https://user-images.githubusercontent.com/17760485/45071185-65336a80-b118-11e8-8cf9-3ceab8132657.png">
    </details>

## Implementation notes
Realised that the icons are squashed together. Tried display inline block instead of block.

And then BAAAM! 

## References
[JIRA ticket](https://zendesk.atlassian.net/browse/OFFAPPS-1041)

## Screenshots
<details>
<summary>Before</summary>
<img width="267" alt="screen shot 2018-09-05 at 2 04 13 pm" src="https://user-images.githubusercontent.com/17760485/45071563-433ae780-b11a-11e8-8074-b5d5aa4cf8d5.png">
</details>

<details>
<summary>After</summary>
<img width="266" alt="screen shot 2018-09-05 at 2 02 34 pm" src="https://user-images.githubusercontent.com/17760485/45071448-b5f79300-b119-11e8-8bba-d7aa589e063a.png">
</details>

<details>
<summary>After (only Twitter)</summary>
<img width="264" alt="screen shot 2018-09-05 at 2 02 11 pm" src="https://user-images.githubusercontent.com/17760485/45071441-a710e080-b119-11e8-804a-05346ee08331.png">


</details>

<details>
<summary>After (only Fb)</summary>
<img width="264" alt="screen shot 2018-09-05 at 2 01 49 pm" src="https://user-images.githubusercontent.com/17760485/45071428-919bb680-b119-11e8-8f47-4a39c7273f04.png">
</details>

## CCs
@zendesk/apps-migration
@sostopher 

## Risks
low - some UI icon arrangements and changes
