### PR TITLE
[OFFAPPS-1043] Remove width on button

### DIFF
--- a/src/main.scss
+++ b/src/main.scss
@@ -53,9 +53,6 @@ html, body {
   .save {
     display: block;
     margin: 20px auto;
-    width: 180px;
-    height: 40px;
-    padding: 0;
     text-align: center;
 
     .spinner {


### PR DESCRIPTION
[OFFAPPS-1043] Remove width on button to prevent long text overflow

## Description
User data app has a configuration page which is accessible via the cog icon at the top right corner. When a user has selected French as their language, the word "Save and go back" is super duper long. As a result, the text overflows out of the button.

## Tasks
- [x] Download the newest translations from Rosetta on my local machine
- [x] Remove width and padding:0; from main.scss
- [x] Run server locally (on _?zat=true_) and checkout the changes

## Implementation notes
- Replicate the bug by assuming into Hiro's Z1 account
- Removing the width allows the button to expend horizontally while containing the text
- Removing padding: 0 allows the use of default padding around the text and the border (outline of button)

## References
[JIRA ticket](https://zendesk.atlassian.net/browse/OFFAPPS-1043)
[Button in Garden](https://garden.zendesk.com/css-components/buttons/)

## Screenshots (if needed)
<details>
<summary>Button Before</summary>
<img width="242" alt="save_button_before" src="https://user-images.githubusercontent.com/17760485/45409606-04290b00-b6b3-11e8-92bd-e50fc1be6d13.png">
</details>

<details>
<summary>Button After</summary>
<img width="300" alt="save_button_after" src="https://user-images.githubusercontent.com/17760485/45409611-08552880-b6b3-11e8-80b4-205e5ab1139b.png">
</details>

<details>
<summary>App After</summary>
<img width="342" alt="screen shot 2018-09-12 at 6 00 25 pm" src="https://user-images.githubusercontent.com/17760485/45410774-edd07e80-b6b5-11e8-8e7e-c51c36432e44.png">
</details>

## CCs
@zendesk/apps-migration
@m-lai 

## Risks
Low - Moved some pixels around
