### PR TITLE
Redirect to requester tab when ticketID is undefined

### DIFF
--- a/src/javascript/app.js
+++ b/src/javascript/app.js
@@ -591,23 +591,23 @@ const app = {
       app.openTicketTab(tabType)
     } else {
       // Open redirection tab for new tickets
-      app.openTab(tabType)
+      app.openUserTab(tabType)
     }
   },
 
   isPersistedTicket: function () {
-    return storage('ticketId')
+    return !!storage('ticketId')
   },
 
   // HACK for navigating to a url, since routeTo doesn't support this.
   // https://developer.zendesk.com/apps/docs/support-api/all_locations#routeto
-  openTicketTab(ticketTab) {
-    let path = ticketTab === 'organization' ? 'tickets' : 'requested_tickets'
+  openTicketTab (ticketTab) {
+    const path = ticketTab === 'organization' ? 'tickets' : 'requested_tickets'
     return client.invoke('routeTo', 'nav_bar', '', `../../tickets/${storage('ticketId')}/${ticketTab}/${path}`)
   },
 
-  openTab(tabType) {
-    let path = tabType === 'organization' ? 'organization/tickets' : 'assigned_tickets'
+  openUserTab (tabType) {
+    const path = tabType === 'organization' ? 'organization/tickets' : 'assigned_tickets'
     return client.invoke('routeTo', 'nav_bar', '', `../../users/${storage('requester').id}/${path}`)
   }
 }

--- a/src/javascript/app.js
+++ b/src/javascript/app.js
@@ -590,22 +590,28 @@ const app = {
   // https://developer.zendesk.com/apps/docs/support-api/all_locations#routeto
   goToRequester: function () {
     if (!storage('ticketId')) {
-      app.openRequesterTab()
+      return app.openRequesterTab()
     } else {
-      return client.invoke('routeTo', 'nav_bar', '', `../../tickets/${storage('ticketId')}/requester/requested_tickets`)
+      return app.routeToNavBar('requester')
     }
   },
 
   goToOrganization: function () {
     if (!storage('ticketId')) {
-      app.openRequesterTab()
+      return app.openRequesterTab()
     } else {
-      return client.invoke('routeTo', 'nav_bar', '', `../../tickets/${storage('ticketId')}/organization/tickets`)
+      return app.routeToNavBar('organization')
     }
   },
 
+  routeToNavBar: function (tabType) {
+    let path = (tabType === 'organization') ? 'organization/tickets' : 'requester/requested_tickets'
+
+    client.invoke('routeTo', 'nav_bar', '', `../../tickets/${storage('ticketId')}/${path}`)
+  },
+
   openRequesterTab: function () {
-    return client.invoke('routeTo', 'user', storage('requester').id)
+    client.invoke('routeTo', 'user', storage('requester').id)
   }
 }
 

--- a/src/javascript/app.js
+++ b/src/javascript/app.js
@@ -586,32 +586,29 @@ const app = {
     return restrictedFields
   },
 
+  goToTab: function (tabType) {
+    if (app.isPersistedTicket()) {
+      app.openTicketTab(tabType)
+    } else {
+      // Open redirection tab for new tickets
+      app.openTab(tabType)
+    }
+  },
+
+  isPersistedTicket: function () {
+    return storage('ticketId')
+  },
+
   // HACK for navigating to a url, since routeTo doesn't support this.
   // https://developer.zendesk.com/apps/docs/support-api/all_locations#routeto
-  goToRequester: function () {
-    if (!storage('ticketId')) {
-      return app.openRequesterTab()
-    } else {
-      return app.routeToNavBar('requester')
-    }
+  openTicketTab(ticketTab) {
+    let path = ticketTab === 'organization' ? 'tickets' : 'requested_tickets'
+    return client.invoke('routeTo', 'nav_bar', '', `../../tickets/${storage('ticketId')}/${ticketTab}/${path}`)
   },
 
-  goToOrganization: function () {
-    if (!storage('ticketId')) {
-      return app.openRequesterTab()
-    } else {
-      return app.routeToNavBar('organization')
-    }
-  },
-
-  routeToNavBar: function (tabType) {
-    let path = (tabType === 'organization') ? 'organization/tickets' : 'requester/requested_tickets'
-
-    client.invoke('routeTo', 'nav_bar', '', `../../tickets/${storage('ticketId')}/${path}`)
-  },
-
-  openRequesterTab: function () {
-    client.invoke('routeTo', 'user', storage('requester').id)
+  openTab(tabType) {
+    let path = tabType === 'organization' ? 'organization/tickets' : 'assigned_tickets'
+    return client.invoke('routeTo', 'nav_bar', '', `../../users/${storage('requester').id}/${path}`)
   }
 }
 
@@ -622,7 +619,7 @@ $(document).on('change', '.org_fields_activate', app.onActivateOrgFieldsChange)
 $(document).on('click', '.back', app.onBackClick)
 $(document).on('click', '.save', app.onSaveClick)
 $(document).on('mouseup', 'textarea', debounce(appResize, 300))
-$(document).on('click', '.card.user .counts a, .card.user .contacts .name a', app.goToRequester)
-$(document).on('click', '.card.org .counts a, .card.user .contacts .organization a, .card.org .contacts .name a', app.goToOrganization)
+$(document).on('click', '.card.user .counts a, .card.user .contacts .name a', () => app.goToTab('requester'))
+$(document).on('click', '.card.org .counts a, .card.user .contacts .organization a, .card.org .contacts .name a', () => app.goToTab('organization'))
 
 export default app

--- a/src/javascript/app.js
+++ b/src/javascript/app.js
@@ -589,11 +589,23 @@ const app = {
   // HACK for navigating to a url, since routeTo doesn't support this.
   // https://developer.zendesk.com/apps/docs/support-api/all_locations#routeto
   goToRequester: function () {
-    return client.invoke('routeTo', 'nav_bar', '', `../../tickets/${storage('ticketId')}/requester/requested_tickets`)
+    if (!storage('ticketId')) {
+      app.openRequesterTab()
+    } else {
+      return client.invoke('routeTo', 'nav_bar', '', `../../tickets/${storage('ticketId')}/requester/requested_tickets`)
+    }
   },
 
   goToOrganization: function () {
-    return client.invoke('routeTo', 'nav_bar', '', `../../tickets/${storage('ticketId')}/organization/tickets`)
+    if (!storage('ticketId')) {
+      app.openRequesterTab()
+    } else {
+      return client.invoke('routeTo', 'nav_bar', '', `../../tickets/${storage('ticketId')}/organization/tickets`)
+    }
+  },
+
+  openRequesterTab: function () {
+    return client.invoke('routeTo', 'user', storage('requester').id)
   }
 }
 


### PR DESCRIPTION
[OFFAPPS-1053] Fix redirection 404 bug when clicking on "new ticket" user data app links

## Description
There are a few links available within the user data app. These links direct agents to requesters' profile, showing their requested tickets.
<details>
<summary>Available links on User Data App</summary>
<img width="257" alt="screen shot 2018-10-02 at 2 26 50 pm 2" src="https://user-images.githubusercontent.com/17760485/46330075-81152800-c654-11e8-913f-68e3d97901a6.png">
</details>

These links do are accessible on existing tickets (submitted tickets) but throws a 404 on new tickets. This is because new tickets do not have a persisted IDs yet. As a result, localStorage(ticketId) is not set. Clicking on the links to ticket/undefined_id will eventually throws a 404.

## Tasks
- [x] investigate what is undefined - localStorage(ticketId) is not set, however localStorage(requester) IS AVAILABLE FOR US TO USE!
- [x] Research on routeTo and paths - apparently ticket and user has different paths
- [x] Redirect user to a new Zendesk Tab (NOT browser tab)
- [x] Pass Lint and Test

## Implementation notes
- As far as I'm aware zaf client doesn't allow access to browser's window.location.url to get new ticket ID to set localStorage(ticketID) and for redirection.
- knowing that localStorage(requester) is available for us, we use this to "redirect" agents by opening a new tab containing Requester Information & requested tickets.

## References
[JIRA ticket](https://zendesk.atlassian.net/browse/OFFAPPS-1053)

## Screenshots (if needed)
<details>
<summary>Before</summary>
<img width="525" alt="click_me" src="https://user-images.githubusercontent.com/17760485/46330089-87a39f80-c654-11e8-8212-8cb3814d12b4.png">

<img width="495" alt="404" src="https://user-images.githubusercontent.com/17760485/46330088-870b0900-c654-11e8-8a04-8582bb5276d3.png">

</details>

<details>
<summary>After</summary>
<img width="523" alt="new_tab" src="https://user-images.githubusercontent.com/17760485/46330092-8a9e9000-c654-11e8-9a08-77c03ed9c8f8.png">
</details>

## CCs
@zendesk/apps-migration

## Risks
* medium | low - fixing a bug on redirection - worst that can happen is ~~the end of the world~~ another 404?