### PR TITLE
Keith/change icon css

### DIFF
--- a/src/main.scss
+++ b/src/main.scss
@@ -124,6 +124,8 @@ i.icon_circle_arrow_left {
 
       textarea {
         height: 72px;
+        width: 98.5%;
+        margin-left: 2px;
       }
 
       &.builtin.tags {

--- a/src/main.scss
+++ b/src/main.scss
@@ -80,27 +80,27 @@ i.icon_circle_arrow_left {
 
   &.new {
     background: #F5CA00;
-    color: #FFFFFF;
+    color: #703B15;
   }
   &.open {
-    background: #E82828;
+    background: #E82A2A;
     color: #FFFFFF;
   }
   &.solved {
-    background: #828282;
-    color: #FFFFFF;
+    background: #68737D;
+    color: #F8F9F9;
   }
   &.pending {
-    background: #59BBE0;
+    background: #259ECB;
     color: #FFFFFF;
   }
   &.hold {
     background: #2F3941;
-    color: #FFFFFF;
+    color: #F8F9F9;
   }
   &.closed {
     background: #D8DCDE;
-    color: #FFFFFF;
+    color: #F8F9F9;
   }
 }
 

--- a/src/main.scss
+++ b/src/main.scss
@@ -89,19 +89,19 @@ i.icon_circle_arrow_left {
   }
   &.solved {
     background: #68737D;
-    color: #F8F9F9;
+    color: #F8F9F9; /* Grey-100 */
   }
   &.pending {
     background: #259ECB;
     color: #FFFFFF;
   }
   &.hold {
-    background: #2F3941;
-    color: #F8F9F9;
+    background: #2F3941; /* Grey-800 */
+    color: #F8F9F9; /* Grey-100 */
   }
   &.closed {
-    background: #D8DCDE;
-    color: #F8F9F9;
+    background: #D8DCDE; /* Grey-300 */
+    color: #49545C; /* Grey-700 */
   }
 }
 

--- a/src/main.scss
+++ b/src/main.scss
@@ -5,7 +5,7 @@
 
 html, body {
   overflow: hidden;
-  padding: 0 2.75px;
+  padding: 0 3px;
 }
 
 .loader {

--- a/src/main.scss
+++ b/src/main.scss
@@ -5,6 +5,7 @@
 
 html, body {
   overflow: hidden;
+  padding: 0 2.75px;
 }
 
 .loader {
@@ -124,8 +125,6 @@ i.icon_circle_arrow_left {
 
       textarea {
         height: 72px;
-        width: 98.5%;
-        margin-left: 2px;
       }
 
       &.builtin.tags {

--- a/src/main.scss
+++ b/src/main.scss
@@ -268,12 +268,13 @@ i.icon_circle_arrow_left {
     .counts {
       margin: 0px;
       margin-top: 30px;
+      display: flex;
+      justify-content: space-between;
 
       li {
         display: inline-block;
         font-size: 12px;
         color: #68737D;
-        width: 48px;
         line-height: 1.486;
 
         a {


### PR DESCRIPTION
[OFFAPPS-1064] CSS changes on badges, overflowing elements and highlighting border! 😄 

## Description
We're changing three things here.
1) Update badge colors to reflect September 2018 standards. Checkout the other pull request in references regarding this.
2) Fix the text area bug (please refer to screenshot on the jira ticket).
3) Fix overflowing badge icon and counts. 

## Tasks
- [x] pass lint and test
- [x] read up on September 2018 standards and identify what to change - colors colors 🌈
- [x] research on flexbox - as suggested by Tony
- [x] research on what Olaf said about textarea and paddings - came up with a hacky band-aid solution

## Implementation notes
### Text Area
<details>
<summary>Before and After</summary>
<img width="263" alt="screen shot 2018-10-03 at 2 00 15 pm" src="https://user-images.githubusercontent.com/17760485/46394823-a6299980-c72d-11e8-9690-af93e5a6c4eb.png">
<img width="264" alt="screen shot 2018-10-03 at 1 58 08 pm" src="https://user-images.githubusercontent.com/17760485/46394847-b8a3d300-c72d-11e8-9bcd-3fa20e8b0e65.png">
</details>
<details>
<summary>How?</summary>
<img width="131" alt="screen shot 2018-10-03 at 1 58 21 pm" src="https://user-images.githubusercontent.com/17760485/46394958-19331000-c72e-11e8-9424-ffd45fa7f32f.png">
</details>
Through console, realised that perhaps the text areas are inheriting the width of the divs they currently resides in. Gave it a width of 98.5% and shifted the box to the right a tiny bit by 2px, so we can see the left and right highlights.

_UPDATE_: Instead of my initial approach, Tony suggested that we shift ~~(squeeze)~~ the entire body horizontally by 3pixels instead. That way, the labels and fields of the app still look aligned. This solution is consistent with the style guidelines. 
<details>
<summary>Updated changes</summary>
<img width="164" alt="screen shot 2018-10-04 at 1 52 04 pm" src="https://user-images.githubusercontent.com/17760485/46452006-ca907f00-c7dc-11e8-9d01-3d4ed6a4c6f5.png">
<img width="317" alt="screen shot 2018-10-04 at 1 53 14 pm" src="https://user-images.githubusercontent.com/17760485/46452094-412d7c80-c7dd-11e8-8fb9-918b7811d09e.png">
</details>


### Badge Colors
Referring to the changes made in this [pull request](https://github.com/zendesk/zendesk_console/pull/16451/files) (September 2018 standards - in reference). Copy paste the hex colors for the different icons

<details>
<summary>Before(left) and After(right)</summary>
<img width="228" alt="bade_colors_before" src="https://user-images.githubusercontent.com/17760485/46395126-b726da80-c72e-11e8-8a7c-5f66d1eca806.png">
VS
<img width="223" alt="badge_colors_after" src="https://user-images.githubusercontent.com/17760485/46395136-c0b04280-c72e-11e8-8284-54b5ab870862.png">
</details>

<details>
<summary>Interested in the code? Before(left), After (right)</summary>
<img width="191" alt="badge_css_before" src="https://user-images.githubusercontent.com/17760485/46395159-d291e580-c72e-11e8-8604-9989846788e7.png">
<img width="172" alt="badge_css_after" src="https://user-images.githubusercontent.com/17760485/46395164-da518a00-c72e-11e8-8913-a09fb82bb0e4.png">
</details>

### Overflowing Badge and Counts
Tony taught me about flexbox not too long ago (attached learning material on flexbox in references). Chris suggested that there should not be a fixed width. Hence I removed the width from `<li>` and introduced flex to `.counts`. 

<details>
<summary>Before(left), After (right)</summary>
<img width="266" alt="screen shot 2018-10-03 at 4 42 32 pm" src="https://user-images.githubusercontent.com/17760485/46395318-47fdb600-c72f-11e8-997d-46924b5c2bfd.png">
<img width="265" alt="screen shot 2018-10-03 at 4 40 48 pm" src="https://user-images.githubusercontent.com/17760485/46395320-492ee300-c72f-11e8-99fa-0d5859e269f7.png">
</details>

## References
[JIRA ticket](https://zendesk.atlassian.net/browse/OFFAPPS-1064)

[September 2018 standards](https://github.com/zendesk/zendesk_console/pull/16451) 
_UPDATE_: Mandy provided [Main Source](https://cl.ly/8289e2f71308) - attn: Olaf

[learning material on flex box](https://jsfiddle.net/zer00ne/ajtd0dLc)



## CCs
@zendesk/apps-migration


## Risks
* low - shifting pixels around 👈 👉 👆 👇 

