### PR TITLE
[OFFAPPS-1074] Fix agent edit textarea

### DIFF
--- a/src/javascript/lib/requests.js
+++ b/src/javascript/lib/requests.js
@@ -44,7 +44,8 @@ export default {
 
   getUser: function (userId) {
     return {
-      url: `/api/v2/users/${userId}.json?include=identities,organizations`
+      url: `/api/v2/users/${userId}.json?include=identities,organizations`,
+      cachable: true
     }
   },
 


### PR DESCRIPTION
## Description
Agents can't edit all users / organisations details, but it still displayed a textarea. Only display textarea in the cases we can actually edit it.

## References
[JIRA ticket](https://zendesk.atlassian.net/browse/OFFAPPS-1074)

## CCs
@zendesk/apps-migration

## Risks
* [low] agents can still edit details that aren't saveable.