### PR TITLE
Put url in ticket link a href

### DIFF
--- a/spec/helpers_spec.js
+++ b/spec/helpers_spec.js
@@ -198,4 +198,43 @@ describe('Helpers', () => {
       })
     })
   })
+
+  describe('#parseQueryString', () => {
+    it('parses without leading ?', () => {
+      const result = helpers.parseQueryString('foo=bar')
+      assert.deepStrictEqual(result, {
+        foo: 'bar'
+      })
+    })
+
+    it('parses booleans', () => {
+      const result = helpers.parseQueryString('?bool_true=true&bool_false=false')
+      assert.deepStrictEqual(result, {
+        bool_true: true,
+        bool_false: false
+      })
+    })
+
+    it('parses numbers', () => {
+      const result = helpers.parseQueryString('?number=123&float=118.1')
+      assert.deepStrictEqual(result, {
+        number: 123,
+        float: 118.1
+      })
+    })
+
+    it('parses arrays', () => {
+      const result = helpers.parseQueryString('?arr=[1,2,"test",[true, false]]')
+      assert.deepStrictEqual(result, {
+        arr: [1, 2, 'test', [true, false]]
+      })
+    })
+
+    it('parses booleans', () => {
+      const result = helpers.parseQueryString('?obj={"foo":"bar","num":123,"bool":true}')
+      assert.deepStrictEqual(result, {
+        obj: { foo: 'bar', num: 123, bool: true }
+      })
+    })
+  })
 })

--- a/src/javascript/app.js
+++ b/src/javascript/app.js
@@ -1,4 +1,4 @@
-import { ajax, urlify, appResize, localStorage, storage, setting, parseNum } from './lib/helpers'
+import { ajax, urlify, appResize, localStorage, storage, setting, parseNum, parseQueryString } from './lib/helpers'
 import I18n from './lib/i18n'
 import client from './lib/client'
 
@@ -392,7 +392,9 @@ const app = {
 
   makeTicketsLinks: function (counters) {
     const links = {}
-    const $tag = $('<div>').append($('<a>').attr('href', 'javascript:void(0)'))
+    const queryData = parseQueryString()
+    const link = `${queryData.origin}/agent/#/tickets/${storage('ticketId')}/requester/requested_tickets`
+    const $tag = $('<div>').append($('<a>').attr('href', link))
     each(counters, function (value, key) {
       if (value && value !== '-') {
         $tag.find('a').html(value)
@@ -616,7 +618,8 @@ const app = {
     return restrictedFields
   },
 
-  goToTab: function (tabType) {
+  goToTab: function (event, tabType) {
+    event.preventDefault()
     if (app.isPersistedTicket()) {
       app.openTicketTab(tabType)
     } else {
@@ -649,7 +652,7 @@ $(document).on('change', '.org_fields_activate', app.onActivateOrgFieldsChange)
 $(document).on('click', '.back', app.onBackClick)
 $(document).on('click', '.save', app.onSaveClick)
 $(document).on('mouseup', 'textarea', debounce(appResize, 300))
-$(document).on('click', '.card.user .counts a, .card.user .contacts .name a', () => app.goToTab('requester'))
-$(document).on('click', '.card.org .counts a, .card.user .contacts .organization a, .card.org .contacts .name a', () => app.goToTab('organization'))
+$(document).on('click', '.card.user .counts a, .card.user .contacts .name a', (event) => app.goToTab(event, 'requester'))
+$(document).on('click', '.card.org .counts a, .card.user .contacts .organization a, .card.org .contacts .name a', (event) => app.goToTab(event, 'organization'))
 
 export default app

--- a/src/javascript/lib/helpers.js
+++ b/src/javascript/lib/helpers.js
@@ -296,3 +296,22 @@ export function parseNum (num) {
          (num >= 1e+4 && (num / 1e+3).toString().slice(0, 3).replace(/\.$/, '') + 'k') ||
          num.toString()
 }
+
+// search param can be used for testing
+export function parseQueryString (search = document.location.search) {
+  if (search.indexOf('?') === 0) search = search.slice(1)
+  const searchData = search.split('&')
+
+  return searchData.reduce((obj, data) => {
+    let [key, value] = data.split('=')
+    key = decodeURIComponent(key)
+    value = decodeURIComponent(value)
+
+    try {
+      value = JSON.parse(value)
+    } catch (err) {}
+
+    obj[key] = value
+    return obj
+  }, {})
+}


### PR DESCRIPTION
## Description
Users have been complaining they can't do 'open in new tab' anymore, so I put the original urls in the link, and preventDefault when you normally click on it. This means you can now use 'open in new tab' and it will work.

## References
[Zendesk ticket](https://support.zendesk.com/agent/tickets/4265248)

## CCs
@zendesk/apps-migration
@zendesk/vegemite 

## Risks
* [low] Ticket Links broken.
