### PR TITLE
[OFFAPPS-1120] Make sure organizations are all there

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ node_js:
 before_install:
   - bundle config zdrepo.jfrog.io $ARTIFACTORY_USERNAME:$ARTIFACTORY_API_KEY
 script:
-  - npm run lint && npm run build && npm run test
+  - npm run lint
+  - npm run test
   - bundle && bundle exec ruby ./validate_strings.rb
 sudo: false
 dist: trusty

--- a/src/javascript/app.js
+++ b/src/javascript/app.js
@@ -46,8 +46,9 @@ const app = {
   },
 
   getInformation: function () {
-    return client.get(['ticket.requester', 'ticket.id', 'ticket.organization', 'currentUser']).then((data) => {
-      const [ requester, ticketId, ticketOrg, currentUser ] = data
+    return client.get(['ticket.requester', 'ticket.id', 'ticket.organization', 'currentUser', 'currentUser.organizations']).then((data) => {
+      const [ requester, ticketId, ticketOrg, currentUser, currentUserOrganizations ] = data
+      currentUser.organizations = currentUserOrganizations
       const promises = []
 
       storage('currentUser', currentUser)

--- a/src/templates/tags.hdbs
+++ b/src/templates/tags.hdbs
@@ -1,6 +1,6 @@
 <ul>
   {{#each tags}}
-    <li class="c-tag c-tag--pill c-tag--light">{{this}}</li>
+    <li class="c-tag c-tag--light">{{this}}</li>
   {{/each}}
 </ul>
 <hr>


### PR DESCRIPTION
## Description
When doing `client.get('currentUser')` the organizations are an empty array. By explicitly added `client.get('currentUser.organizations')` we always get the correct array.

Additionally removed class, to display tag the same as in support.

## References
[JIRA ticket](https://zendesk.atlassian.net/browse/OFFAPPS-1120)

## CCs
@zendesk/apps-migration
@zendesk/vegemite 

## Risks
* [low] Broke edibility of details and/or notes