### PR TITLE
[OFFAPPS-1174] Translations for copy email mechanism

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,7 +29,7 @@ Anyone specific?
 Unless there's a good reason not to:
 @zendesk/apps-migration
 If translation-related:
-@zendesk/i18n
+@zendesk/localization
 
 ## Risks
 * [HIGH | medium | low] Does it work across browsers (including IE!)?

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
+.DS_Store
 tmp/
 dist/
 node_modules/
-src/translations/
+coverage/
+src/translations/*
 !src/translations/en.yml
 .zat

--- a/src/translations/en.yml
+++ b/src/translations/en.yml
@@ -165,3 +165,13 @@ By enabling this app, You agree to the [Built by Zendesk Terms of Use](https://w
       key: "txt.apps.user_data_app.spoke_ticket_id"
       title: "this is the ticket ID from the spoke of that user"
       value: "Spoke ticket ID"
+  - translation:
+      key: "txt.apps.user_data_app.email.click_to_copy"
+      title: "Tooltip that asks user to click to copy the email to their clipboard"
+      value: "Copy email"
+      screenshot: "https://drive.google.com/open?id=11oU9H6NV09JINYllPa7aLOuLITOAMN9y"
+  - translation:
+      key: "txt.apps.user_data_app.email.copied"
+      title: "Tooltip message to indicate that email has been copied to clipboard"
+      value: "Copied"
+      screenshot: "https://drive.google.com/open?id=1rcqcoVVV1r_k2yACEpsfA3wXMRgeAvdy"


### PR DESCRIPTION
[OFFAPPS-1174] Translations for copy email mechanism

## Description & Implementation notes
Translations for "Copied" and "Copy Email" for [this branch](https://github.com/zendesk/user_data_app/pull/114).

**Updated .gitignore because en.yml was included in git ignore**. 

## Tasks
- [ ] Merged this branch first when it gets approved, then merge the [other branch](https://github.com/zendesk/user_data_app/pull/114).

## References
[JIRA ticket](https://zendesk.atlassian.net/browse/OFFAPPS-1174)

## Screenshots
Two screenshots used in src code
<img width="287" alt="copied" src="https://user-images.githubusercontent.com/17760485/56872327-29fcf780-6a6b-11e9-95fd-24b909f7cc52.png">
<img width="285" alt="copy_email" src="https://user-images.githubusercontent.com/17760485/56872328-29fcf780-6a6b-11e9-93d3-d85291ce95e1.png">


## CCs
@hanli625 
@zendesk/apps-migration
@zendesk/localization


## Risks
* [low] Missing translations


[OFFAPPS-1174]: https://zendesk.atlassian.net/browse/OFFAPPS-1174