### PR TITLE
[OFFAPPS-1173] Change SVG colors

### DIFF
--- a/src/main.scss
+++ b/src/main.scss
@@ -4,6 +4,9 @@
 @import '~@zendeskgarden/css-buttons';
 @import '~@zendeskgarden/css-callouts';
 
+$svg-default-color: #68737D;
+$svg-onhover-color: #D8DCDE;
+
 html, body {
   overflow: hidden;
   padding: 0 3px;
@@ -67,7 +70,7 @@ html, body {
 }
 
 .icon_circle_arrow_left {
-  color: #68737D;
+  color: $svg-default-color;
   cursor: pointer;
 
   svg {
@@ -80,7 +83,7 @@ html, body {
     display: inline-block;
 
     &:hover {
-      color: #D8DCDE;
+      color: $svg-onhover-color;
     }
   }
 }
@@ -177,7 +180,7 @@ html, body {
     }
 
     .cog {
-      color: #68737D;
+      color: $svg-default-color;
       cursor: pointer;
 
       svg {
@@ -190,7 +193,7 @@ html, body {
         display: inline-block;
 
         &:hover {
-          color: #D8DCDE;
+          color: $svg-onhover-color;
         }
       }
     }
@@ -253,7 +256,7 @@ html, body {
       margin-left: 34px;
 
       div {
-        color: #68737D;
+        color: $svg-default-color;
         font-size: 14px;
         word-wrap: break-word;
 
@@ -268,7 +271,7 @@ html, body {
 
         &.organization {
           a {
-            color: #68737D;
+            color: $svg-default-color;
           }
         }
 
@@ -291,7 +294,7 @@ html, body {
       li {
         display: inline-block;
         font-size: 12px;
-        color: #68737D;
+        color: $svg-default-color;
         line-height: 1.486;
 
         a {
@@ -327,7 +330,7 @@ html, body {
     height: 18px;
 
     svg {
-      color: #68737D;
+      color: $svg-default-color;
 
       &.expanded {
         transform: rotate(180deg);
@@ -335,7 +338,7 @@ html, body {
 
       &:hover {
         stroke-width: 2;
-        color: #D8DCDE
+        color: $svg-onhover-color;
       }
     }
   }

--- a/src/main.scss
+++ b/src/main.scss
@@ -26,6 +26,7 @@ html, body {
 }
 
 .admin {
+  margin-top: 2px;
   margin-bottom: 15px;
 
   .c_chk {
@@ -66,7 +67,7 @@ html, body {
 }
 
 .icon_circle_arrow_left {
-  color: black;
+  color: #68737D;
   cursor: pointer;
 
   svg {
@@ -79,7 +80,7 @@ html, body {
     display: inline-block;
 
     &:hover {
-      color: #68737D;
+      color: #D8DCDE;
     }
   }
 }
@@ -176,7 +177,7 @@ html, body {
     }
 
     .cog {
-      color: black;
+      color: #68737D;
       cursor: pointer;
 
       svg {
@@ -189,7 +190,7 @@ html, body {
         display: inline-block;
 
         &:hover {
-          color: #68737D;
+          color: #D8DCDE;
         }
       }
     }
@@ -326,7 +327,7 @@ html, body {
     height: 18px;
 
     svg {
-      color: black;
+      color: #68737D;
 
       &.expanded {
         transform: rotate(180deg);
@@ -334,6 +335,7 @@ html, body {
 
       &:hover {
         stroke-width: 2;
+        color: #D8DCDE
       }
     }
   }


### PR DESCRIPTION
[OFFAPPS-1173] Change SVG colors

## Description
Change SVG colors for hover and no hover to GREY-600 or GREY-300

## References
[JIRA ticket](https://zendesk.atlassian.net/browse/OFFAPPS-1173)
[color schemes](https://garden.zendesk.com/css-components/utilities/color/)

## Screenshots
Default state
<img width="291" alt="Screen Shot 2019-05-01 at 12 32 37 pm" src="https://user-images.githubusercontent.com/17760485/57003911-69634980-6c0d-11e9-8f0f-27c3720d734f.png">

Cog on hover
<img width="290" alt="Screen Shot 2019-05-01 at 12 32 51 pm" src="https://user-images.githubusercontent.com/17760485/57003917-6a947680-6c0d-11e9-96f7-17fbddb8bc20.png">

Expend on hover
<img width="288" alt="Screen Shot 2019-05-01 at 12 32 58 pm" src="https://user-images.githubusercontent.com/17760485/57003916-6a947680-6c0d-11e9-9ee7-75fb15ea7f11.png">

Collapse on default
<img width="297" alt="Screen Shot 2019-05-01 at 12 33 05 pm" src="https://user-images.githubusercontent.com/17760485/57003914-69fbe000-6c0d-11e9-8065-26a888939026.png">

Collapse on hover
<img width="298" alt="Screen Shot 2019-05-01 at 12 33 13 pm" src="https://user-images.githubusercontent.com/17760485/57003913-69fbe000-6c0d-11e9-8ee2-72bf57149ff5.png">

Close settings on default
<img width="289" alt="Screen Shot 2019-05-01 at 12 33 24 pm" src="https://user-images.githubusercontent.com/17760485/57003951-ce1ea400-6c0d-11e9-85fa-58a2c4d2097f.png">

Close settings on hover
<img width="296" alt="Screen Shot 2019-05-01 at 12 33 29 pm" src="https://user-images.githubusercontent.com/17760485/57003912-69fbe000-6c0d-11e9-85ee-12839cee834b.png">


## CCs
@zendesk/vegemite 
@zendesk/apps-migration

## Risks
* [low] Wrong svg colors


[OFFAPPS-1173]: https://zendesk.atlassian.net/browse/OFFAPPS-1173